### PR TITLE
Add missing weapon Shotel in Sen's Fortress

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
                     <li data-id="playthrough_10_8">Wait for a boulder and then run up and jump off to the left just before the broken pillar on to a wooden platform</li>
                     <li data-id="playthrough_10_9">Pick up the <a href="http://darksoulswiki.wikispaces.com/Black+Sorcerer+Set">Black Sorcerer Set</a> and <a href="http://darksoulswiki.wikispaces.com/Hush">Hush</a> sorcery</li>
                     <li data-id="playthrough_10_10">Run up to the boulder switch, turn it so that it breaks the wall, then turn it so that it starts filling the hole</li>
-                    <li data-id="playthrough_10_11">Talk to <a href="http://darksoulswiki.wikispaces.com/Siegmeyer+of+Catarina">Siegmeyer of Catarina</a></li>
+                    <li data-id="playthrough_10_11">Pick up the <a href="http://darksoulswiki.wikispaces.com/Shotel">Shotel</a> and talk to <a href="http://darksoulswiki.wikispaces.com/Siegmeyer+of+Catarina">Siegmeyer of Catarina</a></li>
                     <li data-id="playthrough_10_12">Free <a href="http://darksoulswiki.wikispaces.com/Big+Hat+Logan">Big Hat Logan</a></li>
                     <li data-id="playthrough_10_13">Return to the boulder switch and point it outside</li>
                     <li data-id="playthrough_10_14">Run down to the hole the boulder fills, get the <a href="http://darksoulswiki.wikispaces.com/Covetous+Gold+Serpent+Ring">Covetous Gold Serpent Ring</a> and use a <a href="http://darksoulswiki.wikispaces.com/Lloyd%27s+Talisman">Lloyd's Talisman</a> on the mimic chest to get the <a href="http://darksoulswiki.wikispaces.com/Lightning+Spear">Lightning Spear</a></li>


### PR DESCRIPTION
Hi,

Great checklist! While using it I discovered though that the [Shotel](https://darksouls.wiki.fextralife.com/Shotel) is missing from the checklist, unless I missed it somehow? :)