### PR TITLE
Load jQuery from CDN HTTP/S matching original request

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!--[if lt IE 9]>
         <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="//code.jquery.com/jquery-latest.js"></script>
     <script src="js/jstorage.js"></script>
     <script type="text/javascript">
         var profilesKey = 'profiles';


### PR DESCRIPTION
When accessing the Github-hosted page with SSL (https://smcnabb.github.io/dark-souls-cheat-sheet/) Chrome (and possibly other browsers) will refuse to load `jquery-latest.js` because it's requested from a non-HTTPS source. 

<img width="741" alt="Screen Shot 2019-09-21 at 11 59 05 AM" src="https://user-images.githubusercontent.com/1182187/65377999-67a32c80-dc67-11e9-960a-ce2d63d21703.png">

When this happens the initial page content is visible, but tabs can't be clicked and profiles can't be used. This is important as Google has indexed this page at `https://`, so all users entering from search engines will be presented with a page that has broken Javascript. 

One quick fix is simply to change the page URL to http://smcnabb.github.io/dark-souls-cheat-sheet/, and since there aren't HTTPS redirects the page will work as expected. A better fix would be to request jQuery from the same source that the browser loads the page at, simply by removing the `http:` from the jQuery script tag. This will allow both HTTP and HTTPS versions to work properly.